### PR TITLE
fix wrong partial flush statistics for collections

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultAutoFlushEventListener.java
@@ -74,7 +74,7 @@ public class DefaultAutoFlushEventListener extends AbstractFlushingEventListener
 		finally {
 			eventListenerManager.partialFlushEnd(
 					event.getNumberOfEntitiesProcessed(),
-					event.getNumberOfEntitiesProcessed()
+					event.getNumberOfCollectionsProcessed()
 			);
 		}
 	}


### PR DESCRIPTION
wrong value passed to SessionEventListener.partialFlushEnd. second parameter must be number of collections processed not entities processed;